### PR TITLE
fixing errors with showKeyboard / dismissKeyboard

### DIFF
--- a/src/device/cocoon_dialog.js
+++ b/src/device/cocoon_dialog.js
@@ -203,7 +203,7 @@ Cocoon.define("Cocoon.Dialog" , function(extension){
 
         if (Cocoon.nativeAvailable) {
             Cocoon.callNative("IDTK_APP", "showKeyboard", 
-                [params, insertCallback, deleteBackward, doneCallback, cancelCallback], true);
+                [params, insertCallback, deleteCallback, doneCallback, cancelCallback], true);
         }
     };
 
@@ -230,7 +230,7 @@ Cocoon.define("Cocoon.Dialog" , function(extension){
       */
     extension.dismissKeyboard = function() {
         if (Cocoon.nativeAvailable) {
-            Cocoon.callNative("IDTK_APP", "dismissKeyboard", null, true);
+            Cocoon.callNative("IDTK_APP", "dismissKeyboard", [], true);
         }
     }
 


### PR DESCRIPTION
two errors here:
1. is a name typo
2. is that `null` breaks on iOS8 for dismissKeybaord, gotta use [] instead

The keyboard still does not show, though. Any ideas?
