### PR TITLE
Fix missing semi-colon causing unexpected identifier error on chrome 

### DIFF
--- a/build/cocoon.js
+++ b/build/cocoon.js
@@ -2682,7 +2682,7 @@ Cocoon.define("Cocoon.Widget" , function(extension){
             var me = this;
             iframe.onload = function(){
                 me.iframeloaded = true;
-                var js = "Cocoon = {}; Cocoon.Widget = {}; Cocoon.Widget.WebDialog = {} Cocoon.Widget.WebDialog.close = function()" +
+                var js = "Cocoon = {}; Cocoon.Widget = {}; Cocoon.Widget.WebDialog = {}; Cocoon.Widget.WebDialog.close = function()" +
                     "{" +
                     "   window.parent.CocoonJSCloseWebDialog();" +
                     "};";


### PR DESCRIPTION
When trying to open a WebDialog on chrome the missing colon is causing an unexpected identifier error.